### PR TITLE
Add CI workflow with strict ShellCheck and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
           shellcheck -x $(git ls-files '*.sh')
       - name: Run integration tests
         run: |
-          set -e
+          set -euo pipefail
           sudo ./run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
           sudo apt-get install -y shellcheck
       - name: ShellCheck
         run: |
-          set -e
-          shellcheck $(git ls-files '*.sh')
+          set -euo pipefail
+          shellcheck -x $(git ls-files '*.sh')
       - name: Run integration tests
         run: |
           set -e
-          ./run-tests.sh
+          sudo ./run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -16,7 +17,9 @@ jobs:
           sudo apt-get install -y shellcheck
       - name: ShellCheck
         run: |
+          set -e
           shellcheck $(git ls-files '*.sh')
       - name: Run integration tests
         run: |
+          set -e
           ./run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
       - name: ShellCheck
-        run: shellcheck $(git ls-files '*.sh')
+        run: |
+          set -e
+          shellcheck $(git ls-files '*.sh')
       - name: Run integration tests
-        run: ./run-tests.sh
+        run: |
+          set -e
+          ./run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
       - name: ShellCheck
-        run: |
-          set -e
-          shellcheck $(git ls-files '*.sh')
+        run: shellcheck $(git ls-files '*.sh')
       - name: Run integration tests
-        run: |
-          set -e
-          ./run-tests.sh
+        run: ./run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: ShellCheck
+        run: |
+          shellcheck $(git ls-files '*.sh')
+      - name: Run integration tests
+        run: |
+          ./run-tests.sh

--- a/src/security/modules/users/user_utils.sh
+++ b/src/security/modules/users/user_utils.sh
@@ -360,7 +360,7 @@ unlock_user_account() {
     if ! usermod -U "${username}"; then
         log "error" "Falha ao desbloquear a conta do usuário '${username}'"
         return 1
-    }
+    fi
     
     # Remover a expiração da senha
     chage -E -1 "${username}"

--- a/tests/test-common.sh
+++ b/tests/test-common.sh
@@ -134,9 +134,10 @@ validate_username() {
     # Verificar se não termina com hífen ou ponto
     if [[ "$username" =~ [.-]$ ]]; then
         return 1
-    }
+    fi
     
     return 0
+}
 
 # Função para verificar se um comando existe
 command_exists() {


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs ShellCheck and runs integration tests without ignoring failures

## Testing
- `shellcheck $(git ls-files '*.sh')`
- `./run-tests.sh` *(fails: `main.sh: line 843: syntax error near unexpected token `}``)*

------
https://chatgpt.com/codex/tasks/task_e_686b698f26708324aa512d8c3b16194d