### PR TITLE
Ensure dependencies checked before menus

### DIFF
--- a/bin/caprover/setup/setup-caprover.sh
+++ b/bin/caprover/setup/setup-caprover.sh
@@ -63,6 +63,9 @@
 
 set -e
 
+SCRIPT_ROOT="$(cd "$(dirname "$0")"/../../.. && pwd)"
+"${SCRIPT_ROOT}/src/security/core/check_dependencies.sh" --install
+
 LOGFILE="install.log"
 # Rotaciona log antigo
 if [ -f "$LOGFILE" ]; then

--- a/main.sh
+++ b/main.sh
@@ -860,6 +860,8 @@ check_dependencies() {
 
 # Função principal
 main() {
+    "${SCRIPT_DIR}/src/security/core/check_dependencies.sh" --install
+
     # Verificar se há argumentos de linha de comando
     if [ $# -gt 0 ]; then
         case $1 in

--- a/src/ui/menus/caprover_menu.sh
+++ b/src/ui/menus/caprover_menu.sh
@@ -79,7 +79,9 @@ show_caprover_menu() {
 #
 install_caprover() {
     show_header "INSTALAÇÃO DO CAPROVER"
-    
+
+    "${SCRIPT_DIR}/src/security/core/check_dependencies.sh" --install
+
     if command -v caprover &> /dev/null; then
         show_message "info" "CapRover já está instalado."
         return 0
@@ -97,23 +99,8 @@ install_caprover() {
         return 0
     fi
     
-    # Verificar Docker
-    if ! command -v docker &> /dev/null; then
-        show_message "info" "Docker não encontrado. Instalando..."
-        curl -fsSL https://get.docker.com | sh
-        if [ $? -ne 0 ]; then
-            show_message "error" "Falha ao instalar o Docker."
-            return 1
-        fi
-    fi
-    
-    # Instalar CapRover CLI
-    show_message "info" "Instalando CapRover CLI..."
-    npm install -g caprover
-    if [ $? -ne 0 ]; then
-        show_message "error" "Falha ao instalar o CapRover CLI. Verifique se o Node.js está instalado."
-        return 1
-    fi
+
+    # Dependências já verificadas pelo check_dependencies.sh
     
     # Instalar CapRover
     show_message "info" "Iniciando instalação do CapRover..."


### PR DESCRIPTION
## Summary
- auto-install dependencies via `check_dependencies.sh` when main script runs
- call dependency checker before CapRover installation routines
- add caprover related packages to dependency list and npm install helper

## Testing
- `bash run-tests.sh` *(fails: interactive)*

------
https://chatgpt.com/codex/tasks/task_e_686c4cba85748324a92c8b07f5095b17